### PR TITLE
Bugfix/str 4114 illuminatecontractsfilesystemfi

### DIFF
--- a/src/Commands/ClearModulesCacheCommand.php
+++ b/src/Commands/ClearModulesCacheCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Nwidart\Modules\Commands;
+
+use Illuminate\Console\Command;
+use Nwidart\Modules\Traits\CanClearModulesCache;
+
+class ClearModulesCacheCommand extends Command
+{
+    use CanClearModulesCache;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'module:clear-cache {--force}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear the modules cache';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $force = $this->option('force');
+        $this->clearCache($force);
+        $this->info('The modules cache has been cleared.');
+    }
+}

--- a/src/Json.php
+++ b/src/Json.php
@@ -114,14 +114,13 @@ class Json
      */
     public function getContents()
     {
-        if ($this->filesystem->exists($this->getPath())) {
-            return $this->filesystem->get($this->getPath());
+        if ($this->filesystem->exists($this->getPath()) === false) {
+            $this->clearCache();
         }
-        $this->clearCache();
-        if ($this->filesystem->exists($this->getPath())) {
-            return $this->filesystem->get($this->getPath());
+        if ($this->filesystem->exists($this->getPath()) === false) {
+            throw new FileNotFoundException($this->getPath());
         }
-        throw new FileNotFoundException($this->getPath());
+        return $this->filesystem->get($this->getPath());
     }
 
     /**

--- a/src/Json.php
+++ b/src/Json.php
@@ -2,11 +2,15 @@
 
 namespace Nwidart\Modules;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Nwidart\Modules\Exceptions\InvalidJsonException;
+use Nwidart\Modules\Traits\CanClearModulesCache;
 
 class Json
 {
+    use CanClearModulesCache;
+
     /**
      * The file path.
      *
@@ -106,10 +110,18 @@ class Json
      * Get file content.
      *
      * @return string
+     * @throws FileNotFoundException
      */
     public function getContents()
     {
-        return $this->filesystem->get($this->getPath());
+        if ($this->filesystem->exists($this->getPath())) {
+            return $this->filesystem->get($this->getPath());
+        }
+        $this->clearCache();
+        if ($this->filesystem->exists($this->getPath())) {
+            return $this->filesystem->get($this->getPath());
+        }
+        throw new FileNotFoundException($this->getPath());
     }
 
     /**

--- a/src/Json.php
+++ b/src/Json.php
@@ -114,9 +114,10 @@ class Json
      */
     public function getContents()
     {
-        if ($this->filesystem->exists($this->getPath()) === false) {
-            $this->clearCache();
+        if ($this->filesystem->exists($this->getPath()) === true) {
+            return $this->filesystem->get($this->getPath());
         }
+        $this->clearCache();
         if ($this->filesystem->exists($this->getPath()) === false) {
             throw new FileNotFoundException($this->getPath());
         }

--- a/src/Module.php
+++ b/src/Module.php
@@ -15,6 +15,8 @@ abstract class Module
 {
     use Macroable;
 
+    public const MODULE_JSON_FILE = 'module.json';
+
     /**
      * The laravel|lumen application instance.
      *
@@ -220,11 +222,12 @@ abstract class Module
     public function json($file = null) : Json
     {
         if ($file === null) {
-            $file = 'module.json';
+            $file = self::MODULE_JSON_FILE;
         }
 
         return Arr::get($this->moduleJson, $file, function () use ($file) {
-            return $this->moduleJson[$file] = new Json($this->getPath() . '/' . $file, $this->files);
+            $path = $this->getPath() . DIRECTORY_SEPARATOR . $file;
+            return $this->moduleJson[$file] = new Json($path, $this->files);
         });
     }
 

--- a/src/Traits/CanClearModulesCache.php
+++ b/src/Traits/CanClearModulesCache.php
@@ -6,10 +6,11 @@ trait CanClearModulesCache
 {
     /**
      * Clear the modules cache if it is enabled
+     * @param bool $force
      */
-    public function clearCache()
+    public function clearCache($force = false)
     {
-        if (config('modules.cache.enabled') === true) {
+        if ($force === true || config('modules.cache.enabled') === true) {
             app('cache')->forget(config('modules.cache.key'));
         }
     }


### PR DESCRIPTION
This offers two method to solve the issued outlined here:

https://github.com/nWidart/laravel-modules/issues/1054

1. We now have a command that we can run to clear the cache (by force, overriding what's in the config) if we need to.
2. If we don't have a modules.json file, then we're probably in the wrong path, so clearing the cache will fix this. Failing that, we (more) gracefully throw an exception, which can be caught, rather than a fatal error we had previously.